### PR TITLE
Feature s3 compatible object storage for backupbuckets

### DIFF
--- a/example/30-backupbucket.yaml
+++ b/example/30-backupbucket.yaml
@@ -11,6 +11,7 @@ data:
 # endpoint: base64(custom endpoint for S3 compatible object storage)
 # s3ForcePathStyle: base64(force path style for storing objects, necessary for S3 compatible storage)
 # trustedCaCert: base64(trusted ca certificate in pem format. Necessary custom CAs)
+# insecureSkipVerify: base64(boolean switch for skipping TLS verification)
 ---
 apiVersion: extensions.gardener.cloud/v1alpha1
 kind: BackupBucket

--- a/example/30-backupbucket.yaml
+++ b/example/30-backupbucket.yaml
@@ -8,6 +8,9 @@ type: Opaque
 data:
 # accessKeyID: base64(access-key-id)
 # secretAccessKey: base64(secret-access-key)
+# endpoint: base64(custom endpoint for S3 compatible object storage)
+# s3ForcePathStyle: base64(force path style for storing objects, necessary for S3 compatible storage)
+# trustedCaCert: base64(trusted ca certificate in pem format. Necessary custom CAs)
 ---
 apiVersion: extensions.gardener.cloud/v1alpha1
 kind: BackupBucket

--- a/pkg/aws/client/types.go
+++ b/pkg/aws/client/types.go
@@ -46,6 +46,7 @@ type Interface interface {
 	// S3 wrappers
 	DeleteObjectsWithPrefix(ctx context.Context, bucket, prefix string) error
 	CreateBucketIfNotExists(ctx context.Context, bucket, region string) error
+	S3CompatCreateBucketIfNotExists(ctx context.Context, bucket, region string) error
 	DeleteBucketIfExists(ctx context.Context, bucket string) error
 
 	// Route53 wrappers

--- a/pkg/aws/secret.go
+++ b/pkg/aws/secret.go
@@ -7,6 +7,7 @@ package aws
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	corev1 "k8s.io/api/core/v1"
@@ -49,10 +50,24 @@ func ReadCredentialsSecret(secret *corev1.Secret, allowDNSKeys bool) (*Credentia
 
 	region, _ := getSecretDataValue(secret, Region, altRegionKey, false)
 
+	endpoint, _ := getSecretDataValue(secret, Endpoint, nil, false)
+
+	s3ForcePathStyle, _ := getSecretDataValue(secret, S3ForcePathStyle, nil, false)
+	s3ForcePathStyleBool, _ := strconv.ParseBool(string(s3ForcePathStyle))
+
+	insecureSkipVerify, _ := getSecretDataValue(secret, InsecureSkipVerify, nil, false)
+	insecureSkipVerifyBool, _ := strconv.ParseBool(string(insecureSkipVerify))
+
+	trustedCaCert, _ := getSecretDataValue(secret, TrustedCaCert, nil, false)
+
 	return &Credentials{
-		AccessKeyID:     accessKeyID,
-		SecretAccessKey: secretAccessKey,
-		Region:          region,
+		AccessKeyID:        accessKeyID,
+		SecretAccessKey:    secretAccessKey,
+		Region:             region,
+		Endpoint:           endpoint,
+		S3ForcePathStyle:   s3ForcePathStyleBool,
+		InsecureSkipVerify: insecureSkipVerifyBool,
+		TrustedCaCert:      trustedCaCert,
 	}, nil
 }
 
@@ -63,7 +78,20 @@ func NewClientFromSecretRef(ctx context.Context, client client.Client, secretRef
 	if err != nil {
 		return nil, err
 	}
-	return awsclient.NewClient(string(credentials.AccessKeyID), string(credentials.SecretAccessKey), region)
+
+	if credentials.Endpoint != nil {
+		return awsclient.NewS3CompatClient(
+			string(credentials.AccessKeyID),
+			string(credentials.SecretAccessKey),
+			region,
+			string(credentials.Endpoint),
+			credentials.TrustedCaCert,
+			credentials.S3ForcePathStyle,
+			credentials.InsecureSkipVerify,
+		)
+	} else {
+		return awsclient.NewClient(string(credentials.AccessKeyID), string(credentials.SecretAccessKey), region)
+	}
 }
 
 func getSecretDataValue(secret *corev1.Secret, key string, altKey *string, required bool) ([]byte, error) {

--- a/pkg/aws/types.go
+++ b/pkg/aws/types.go
@@ -59,6 +59,14 @@ const (
 	SharedCredentialsFile = "credentialsFile"
 	// Region is a constant for the key in a backup secret that holds the AWS region.
 	Region = "region"
+	// Endpoint is a custom endpoint to use for example for S3 compatible storage
+	Endpoint = "endpoint"
+	// Boolean for enabling path-style addressing for S3 compatible storage
+	S3ForcePathStyle = "s3ForcePathStyle"
+	// InsecureSkipVerify controls whether a client verifies the server's certificate chain and host name
+	InsecureSkipVerify = "insecureSkipVerify"
+	// RootCA to be added to the list of root certificate authorities that clients use when verifying server certificates
+	TrustedCaCert = "trustedCaCert"
 	// DNSAccessKeyID is a constant for the key in a DNS secret that holds the AWS access key id.
 	DNSAccessKeyID = "AWS_ACCESS_KEY_ID"
 	// DNSSecretAccessKey is a constant for the key in a DNS secret that holds the AWS secret access key.
@@ -128,7 +136,11 @@ var (
 
 // Credentials stores AWS credentials.
 type Credentials struct {
-	AccessKeyID     []byte
-	SecretAccessKey []byte
-	Region          []byte
+	AccessKeyID        []byte
+	SecretAccessKey    []byte
+	Region             []byte
+	Endpoint           []byte
+	S3ForcePathStyle   bool
+	InsecureSkipVerify bool
+	TrustedCaCert      []byte
 }

--- a/pkg/controller/backupbucket/actuator.go
+++ b/pkg/controller/backupbucket/actuator.go
@@ -7,6 +7,7 @@ package backupbucket
 import (
 	"context"
 
+	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	"github.com/gardener/gardener/extensions/pkg/controller/backupbucket"
 	"github.com/gardener/gardener/extensions/pkg/util"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
@@ -33,6 +34,15 @@ func (a *actuator) Reconcile(ctx context.Context, _ logr.Logger, bb *extensionsv
 	awsClient, err := aws.NewClientFromSecretRef(ctx, a.client, bb.Spec.SecretRef, bb.Spec.Region)
 	if err != nil {
 		return util.DetermineError(err, helper.KnownCodes)
+	}
+
+	secret, err := extensionscontroller.GetSecretByReference(ctx, a.client, &bb.Spec.SecretRef)
+	if err != nil {
+		return err
+	}
+
+	if secret.Data["endpoint"] != nil {
+		return util.DetermineError(awsClient.S3CompatCreateBucketIfNotExists(ctx, bb.Name, bb.Spec.Region), helper.KnownCodes)
 	}
 
 	return util.DetermineError(awsClient.CreateBucketIfNotExists(ctx, bb.Name, bb.Spec.Region), helper.KnownCodes)


### PR DESCRIPTION
**How to categorize this PR?**
/area backup
/kind enhancement
/platform aws

**What this PR does / why we need it**:
Adds funktionality to backup to S3 compatible object storage.

**Special notes for your reviewer**:
The following additional parameters can be used within the secret referenced by a `backupbucket` for for storing backups on a S3 compatible object storage like e.g. Minio:

- endpoint
  This parameter specifies the custom S3 endpoint to backup

- s3ForcePathStyle
  Forces the path style for storing objects, necessary for S3 compatible storage.

- trustedCaCert
  A trusted CA certificate in PEM format

- insecureSkipVerify
  Boolean switch for skipping TLS verification.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```
- category: feature
- target_group: operator

Adding feature to store Shoot-backups in S3 compatible object storage.
```
